### PR TITLE
implement simple repl

### DIFF
--- a/monkey-lexer/src/lib.rs
+++ b/monkey-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 use monkey_token::{
-    lookup_ident, Token, TokenType, ASSIGN, ASTERISK, BANG, COMMA, EQ, GT, ILLEGAL, INT, LBRACE,
-    LPAREN, LT, MINUS, NOT_EQ, RBRACE, RPAREN, SEMICOLON, SLASH,
+    lookup_ident, Token, TokenType, ASSIGN, ASTERISK, BANG, COMMA, EOF, EQ, GT, ILLEGAL, INT,
+    LBRACE, LPAREN, LT, MINUS, NOT_EQ, RBRACE, RPAREN, SEMICOLON, SLASH,
 };
 #[derive(Debug)]
 pub struct Lexer {
@@ -52,6 +52,10 @@ impl Lexer {
         };
         self.skip_whitespace();
         let token = match self.ch {
+            '\0' => {
+                token = Self::new_token(EOF.to_string(), self.ch.to_string());
+                token
+            }
             '=' => {
                 if self.peek_char() == '=' {
                     let ch = self.ch;
@@ -140,7 +144,6 @@ impl Lexer {
                 token
             }
             _ => {
-                dbg!(self.ch);
                 if self.is_letter() {
                     token.Literal = self.read_identifier();
                     token.Type = lookup_ident(&token.Literal);
@@ -151,12 +154,12 @@ impl Lexer {
                     token.Literal = self.read_number();
                     token
                 } else {
+                    dbg!(self.ch);
                     Self::new_token(ILLEGAL.to_string(), self.ch.to_string())
                 }
             }
         };
 
-        dbg!(self.position);
         token
     }
     fn new_token(assign: TokenType, ch: String) -> Token {
@@ -166,6 +169,9 @@ impl Lexer {
         };
     }
 
+    pub fn endofinput(&self) -> bool {
+        (self.input.len() as u8) < self.readPosition
+    }
     ///
     fn is_letter(&self) -> bool {
         self.ch.is_alphabetic() || self.ch == '_'
@@ -176,13 +182,12 @@ impl Lexer {
             self.read_char(); // 次の文字を読み込む
         }
         let identifier = &self.input[start_pos as usize..self.position as usize];
-        dbg!(self.position);
         identifier.to_string() // 文字列を返す
     }
 
     /// スペースであるかぎりスキップする
     fn skip_whitespace(&mut self) -> () {
-        while self.ch == ' ' || self.ch == '\t' || self.ch == '\n' {
+        while self.ch == ' ' || self.ch == '\t' || self.ch == '\n' || self.ch == '\r' {
             self.read_char();
         }
     }
@@ -197,7 +202,7 @@ impl Lexer {
             self.read_char(); // 次の文字を読み込む
         }
         let identifier = &self.input[start_pos as usize..self.position as usize];
-        dbg!(self.position);
+
         identifier.to_string() // 文字列を返す
     }
 

--- a/monkey-repl/Cargo.toml
+++ b/monkey-repl/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "monkey-repl"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+"monkey-lexer"={path="../monkey-lexer"}

--- a/monkey-repl/src/main.rs
+++ b/monkey-repl/src/main.rs
@@ -1,0 +1,28 @@
+use std::io::{self, Write};
+
+use monkey_lexer::Lexer;
+
+const PROMPT: &str = ">> ";
+
+fn main() -> io::Result<()> {
+    let mut input = String::new();
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+
+    loop {
+        print!("{}", PROMPT);
+        stdout.flush()?; // プロンプトを表示
+        input.clear();
+        stdin.read_line(&mut input)?; // ユーザーからの入力を受け取る
+
+        let mut lexer = Lexer::new(input.clone());
+        loop {
+            let tok = lexer.NextToken();
+            if lexer.endofinput() {
+                break;
+            }
+            // トークンを表示
+            writeln!(stdout, "{:?}", tok)?;
+        }
+    }
+}

--- a/monkey-token/src/lib.rs
+++ b/monkey-token/src/lib.rs
@@ -46,7 +46,6 @@ pub struct Token {
 }
 use std::collections::HashMap;
 pub fn lookup_ident(ident: &str) -> TokenType {
-    dbg!(ident);
     let mut map = HashMap::new();
     map.insert("fn", FUNCTION);
     map.insert("let", LET);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a command-line interface for the REPL, allowing users to interactively input and evaluate expressions.
	- Enhanced token recognition capabilities by adding an `EOF` token type and improved whitespace handling.
  
- **Bug Fixes**
	- Streamlined the `lookup_ident` function by removing unnecessary debug statements.

- **Documentation**
	- Added a `Cargo.toml` file for the `monkey-repl` package with dependency information and links to Rust documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->